### PR TITLE
make code block support add language hint like other Markdown Editor

### DIFF
--- a/Source/HtmlProcessor.cpp
+++ b/Source/HtmlProcessor.cpp
@@ -46,7 +46,7 @@ void HtmlProcessor::renderHtmlContent (const ValueTree& docTree,
     const String& htmlContentStr (Md2Html::mdStringToHtml (mdStrWithoutAbbrev));
 
     // process code
-    if (htmlContentStr.contains ("<pre><code>"))
+    if (htmlContentStr.contains ("</code></pre>"))
     {
         tplStr = tplStr.replace ("\n  <title>",
                                  "\n  <script src = \""

--- a/Source/SwingLibrary/MD2Html.cpp
+++ b/Source/SwingLibrary/MD2Html.cpp
@@ -124,8 +124,13 @@ const String Md2Html::codeBlockParse (const String& mdString)
             break;
 
         const String mdCode (resultStr.substring (indexStart, indexEnd + 3));
-        const String htmlStr ("<pre><code>"
-                              + mdCode.replace ("```", String())
+
+		const int codeStyleIndexEnd = mdCode.indexOf(0, "\n");
+		const String highlightStyle (mdCode.substring(3, codeStyleIndexEnd).trim());
+		String mdCodeNew = mdCode.substring(codeStyleIndexEnd);
+
+        const String htmlStr ("<pre><code class=\"" + highlightStyle + "\">"
+                              + mdCodeNew.replace ("```", String())
                               .replace ("*", "_%5x|z%!##!_") // see cleanup(), prevent bold and italic parse it
                               .replace ("<", "&lt;").replace (">", "&gt;")  // escape html code
                               + "</code></pre>");
@@ -729,7 +734,7 @@ const String Md2Html::cleanUp (const String& mdString)
     }
 
     // clean extra <p> and <br> which is in code-block(s)
-    int indexCodeStart = resultStr.indexOfIgnoreCase (0, "<pre><code>");
+    int indexCodeStart = resultStr.indexOfIgnoreCase (0, "<pre><code");
 
     while (indexCodeStart != -1 && indexCodeStart + 16 <= resultStr.length())
     {
@@ -742,7 +747,7 @@ const String Md2Html::cleanUp (const String& mdString)
         const String codeHtml (mdCode.replace ("<p>", newLine).replace ("<br>", String()));
 
         resultStr = resultStr.replaceSection (indexCodeStart, mdCode.length(), codeHtml);
-        indexCodeStart = resultStr.indexOfIgnoreCase (indexCodeStart + 16, "<pre><code>");
+        indexCodeStart = resultStr.indexOfIgnoreCase (indexCodeStart + 16, "<pre><code");
     }
 
     // clean extra <p> and <br> which is in page's js-code (inside <body/>)


### PR DESCRIPTION
for example, just in github. 
```markdown
\```python
import os
\```
```
rendered as
```python
import os
```